### PR TITLE
include package.json when copying webpack modules

### DIFF
--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -3,7 +3,8 @@ const CopyModulesPlugin = require("copy-modules-webpack-plugin");
 module.exports = {
   plugins: [
     new CopyModulesPlugin({
-      destination: 'webpack-modules'
+      destination: 'webpack-modules',
+      includePackageJsons: true
     })
   ]
 }


### PR DESCRIPTION
should change IQ findings from a-name to npm, and probably more expected versions